### PR TITLE
Add reference mapping step

### DIFF
--- a/bin/identify_cnmf_programs.py
+++ b/bin/identify_cnmf_programs.py
@@ -17,12 +17,14 @@ import re
 from pathlib import Path
 
 import numpy as np
+import scanpy as sc
 from cnmf import cNMF
 
 
 def _parse_args() -> argparse.Namespace:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--h5ad", required=True, type=Path, help=".h5ad produced by SPLIT_SAMPLES")
+    ap.add_argument("--h5ad", required=True, type=Path, help=".h5ad file")
+    ap.add_argument("--id", required=True, help="Sample id")
     ap.add_argument("--out-dir", required=True, type=Path, help="Directory to create (will be <uid>_cnmf)")
     ap.add_argument(
         "--components", default="10,15,20", type=parse_comma_ints, help="Comma-separated list of k; e.g. 5,10,15"
@@ -51,9 +53,16 @@ def main() -> None:
     args = _parse_args()
     k_list = np.arange(*args.components)
 
+    # Filtering before CNMF analysis
+    adata = sc.read(args.h5ad)
+    sc.pp.filter_cells(adata, min_counts=10)
+    sc.pp.filter_genes(adata, min_cells=5)
+    adata_path = args.id + ".h5ad"
+    adata.write_h5ad(adata_path)
+
     cnmf = cNMF(name=args.out_dir.as_posix())
     cnmf.prepare(
-        counts_fn=args.h5ad.as_posix(),
+        counts_fn=adata_path,
         components=k_list,
         n_iter=args.n_iter,
         num_highvar_genes=args.num_highvar_genes,

--- a/bin/map_reference.py
+++ b/bin/map_reference.py
@@ -36,6 +36,18 @@ def _parse_args():
     return args
 
 
+def ensure_raw_counts(adata):
+    if RAW_COUNTS in adata.layers:
+        adata.X = adata.layers[RAW_COUNTS].copy()
+        return adata
+    if adata.raw is not None:
+        adata = adata.raw.to_adata()
+        return adata
+    if "log1p" in adata.uns:
+        raise ValueError("The data was log-transformed and raw counts are not available")
+    return adata
+
+
 def preprocess_standard(adata):
     sc.pp.filter_cells(adata, min_counts=10)
     adata.layers[RAW_COUNTS] = adata.X.copy()
@@ -57,14 +69,15 @@ def cluster_adata(adata):
 def get_marker_genes(adata_in, cluster_col, top_n):
     adata = adata_in.copy()
     adata.X = adata.layers[LOGSCALED_COUNTS]
-    sc.tl.rank_genes_groups(adata, groupby=cluster_col, use_raw=False, method="wilcoxon")
-    groups = adata.obs[cluster_col].astype("category").cat.categories
-    markers = []
-    for group in groups:
-        df = sc.get.rank_genes_groups_df(adata, group=group)
-        top_genes = df.sort_values("scores", ascending=False)["names"].head(top_n).tolist()
-        markers.extend(top_genes)
-    return markers
+    sc.tl.rank_genes_groups(
+        adata,
+        groupby=cluster_col,
+        use_raw=False,
+        method="wilcoxon",
+        n_genes=top_n,
+    )
+    df = sc.get.rank_genes_groups_df(adata, group=None)
+    return df["names"].drop_duplicates().tolist()
 
 
 def get_tangram_predictions(adata, perc=0, merge=True):
@@ -91,10 +104,11 @@ def main():
     adata_st = cluster_adata(adata_st)
 
     adata_sc = sc.read(args.reference_file.resolve())
+    adata_sc = ensure_raw_counts(adata_sc)
     adata_sc = preprocess_standard(adata_sc)
 
-    genes_sc = get_marker_genes(adata_sc, args.cell_type_key, 10)
-    genes_st = get_marker_genes(adata_st, CLUSTER_COL, 10)
+    genes_sc = get_marker_genes(adata_sc, args.cell_type_key, 100)
+    genes_st = get_marker_genes(adata_st, CLUSTER_COL, 100)
 
     genes_shared = np.intersect1d(genes_sc, genes_st)
 

--- a/bin/map_reference.py
+++ b/bin/map_reference.py
@@ -8,7 +8,10 @@ import pandas as pd
 import scanpy as sc
 import tangram as tg
 
-LAYER_KEY = "counts"
+RAW_COUNTS = "counts"
+LOGSCALED_COUNTS = "scaled_counts"
+CLUSTER_COL = "leiden"
+UNASSIGNED_KEY = "Unassigned"
 
 
 def _parse_args():
@@ -33,13 +36,17 @@ def _parse_args():
     return args
 
 
-def cluster_adata(adata, hvg=True, n_top_genes=2000):
+def preprocess_standard(adata):
     sc.pp.filter_cells(adata, min_counts=10)
-    adata.layers[LAYER_KEY] = adata.X.copy()
+    adata.layers[RAW_COUNTS] = adata.X.copy()
     sc.pp.normalize_total(adata)
     sc.pp.log1p(adata)
-    if hvg:
-        sc.pp.highly_variable_genes(adata, n_top_genes=n_top_genes)
+    adata.layers[LOGSCALED_COUNTS] = adata.X.copy()
+    sc.pp.highly_variable_genes(adata)
+    return adata
+
+
+def cluster_adata(adata):
     sc.tl.pca(adata)
     sc.pp.neighbors(adata)
     sc.tl.umap(adata)
@@ -47,50 +54,17 @@ def cluster_adata(adata, hvg=True, n_top_genes=2000):
     return adata
 
 
-def bin_entropy(x, axis=1):
-    """Calculates Shannon entropy with the base of 2 on count data."""
-    x = np.atleast_2d(x).astype(int)
-
-    if axis == 0:
-        x = x.T
-
-    nrows, ncols = x.shape
-    nbins = x.max() + 1
-
-    counts = np.vstack([np.bincount(row, minlength=nbins) for row in x])
-
-    p = counts / float(ncols)
-    p = np.where(p > 0, p, 1)
-
-    return -np.sum(p * np.log2(p), axis=1)
-
-
-def calculate_cluster_entropy(adata, cluster_col):
-    X = adata.X.toarray()
-    cluster_labels = adata.obs[cluster_col].values
-    unique_clusters = np.unique(cluster_labels)
-    n_clusters = len(unique_clusters)
-
-    avg_gene_values = np.zeros((n_clusters, X.shape[1]))
-
-    for i, cluster in enumerate(unique_clusters):
-        cluster_indices = np.where(cluster_labels == cluster)[0]
-
-        avg_gene_values[i, :] = X[cluster_indices].mean(axis=0)
-
-    avg_gene_values_transposed = avg_gene_values.T
-
-    entropies = bin_entropy(avg_gene_values_transposed, axis=1)
-
-    return entropies
-
-
-def get_informative_genes(adata, cluster_col, threshold=0.01):
-    gene_names = adata.var_names
-    entropies = calculate_cluster_entropy(adata, cluster_col)
-    gene_entropies = zip(gene_names, entropies)
-    filtered_genes = filter(lambda x: x[1] > threshold, gene_entropies)
-    return [gene[0] for gene in filtered_genes]
+def get_marker_genes(adata_in, cluster_col, top_n):
+    adata = adata_in.copy()
+    adata.X = adata.layers[LOGSCALED_COUNTS]
+    sc.tl.rank_genes_groups(adata, groupby=cluster_col, use_raw=False, method="wilcoxon")
+    groups = adata.obs[cluster_col].astype("category").cat.categories
+    markers = []
+    for group in groups:
+        df = sc.get.rank_genes_groups_df(adata, group=group)
+        top_genes = df.sort_values("scores", ascending=False)["names"].head(top_n).tolist()
+        markers.extend(top_genes)
+    return markers
 
 
 def get_tangram_predictions(adata, perc=0, merge=True):
@@ -112,20 +86,26 @@ def get_tangram_predictions(adata, perc=0, merge=True):
 def main():
     args = _parse_args()
     adata_xm = sc.read(args.xenium_file.resolve())
+    adata_st = adata_xm.copy()
+    adata_st = preprocess_standard(adata_st)
+    adata_st = cluster_adata(adata_st)
+
     adata_sc = sc.read(args.reference_file.resolve())
+    adata_sc = preprocess_standard(adata_sc)
 
-    adata = adata_xm.copy()
-    adata = cluster_adata(adata)
-
-    genes_sc = get_informative_genes(adata_sc, args.cell_type_key)
-    genes_st = get_informative_genes(adata, "leiden")
+    genes_sc = get_marker_genes(adata_sc, args.cell_type_key, 10)
+    genes_st = get_marker_genes(adata_st, CLUSTER_COL, 10)
 
     genes_shared = np.intersect1d(genes_sc, genes_st)
-    tg.pp_adatas(adata_sc, adata, genes=genes_shared, gene_to_lowercase=False)
+
+    if genes_shared.shape[0] == 0:
+        raise ValueError("0 genes selected for mapping. Adjust the config or find a better reference.")
+
+    tg.pp_adatas(adata_sc, adata_st, genes=genes_shared, gene_to_lowercase=False)
 
     ad_map = tg.map_cells_to_space(
         adata_sc,
-        adata,
+        adata_st,
         mode="clusters",
         cluster_label=args.cell_type_key,
         density_prior="uniform",
@@ -137,14 +117,14 @@ def main():
     plt.savefig(args.training_plot, dpi=300, bbox_inches="tight")
     plt.close()
 
-    tg.project_cell_annotations(ad_map, adata, annotation=args.cell_type_key)
-    adata = get_tangram_predictions(adata)
+    tg.project_cell_annotations(ad_map, adata_st, annotation=args.cell_type_key)
+    adata_st = get_tangram_predictions(adata_st)
 
-    tangram_df = adata_xm.obs.join(adata.obs[["tangram_prediction", "tangram_score"]], how="left")
+    tangram_df = adata_xm.obs.join(adata_st.obs[["tangram_prediction", "tangram_score"]], how="left")
     adata_xm.obs = tangram_df
-    adata_xm.obs["tangram_prediction"] = adata_xm.obs["tangram_prediction"].fillna("unassigned")
+    adata_xm.obs["tangram_prediction"] = adata_xm.obs["tangram_prediction"].fillna(UNASSIGNED_KEY)
 
-    adata_xm.write_h5ad(args.out.resolve())
+    adata_st.write_h5ad(args.out.resolve())
 
 
 if __name__ == "__main__":

--- a/bin/map_reference.py
+++ b/bin/map_reference.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import scanpy as sc
+import tangram as tg
+
+LAYER_KEY = "counts"
+
+
+def _parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--xenium-file", required=True, type=Path)
+    p.add_argument("--reference-file", required=True, type=Path)
+    p.add_argument("--out", required=True, type=Path)
+    p.add_argument(
+        "--cell-type-key",
+        required=True,
+        type=str,
+        help="Column in reference AnnData .obs containing cell type labels.",
+    )
+    p.add_argument(
+        "--training-plot",
+        default=None,
+        required=True,
+        type=Path,
+        help="Optional path to save Tangram training scores plot.",
+    )
+    args = p.parse_args()
+    return args
+
+
+def cluster_adata(adata, hvg=True, n_top_genes=2000):
+    sc.pp.filter_cells(adata, min_counts=10)
+    adata.layers[LAYER_KEY] = adata.X.copy()
+    sc.pp.normalize_total(adata)
+    sc.pp.log1p(adata)
+    if hvg:
+        sc.pp.highly_variable_genes(adata, n_top_genes=n_top_genes)
+    sc.tl.pca(adata)
+    sc.pp.neighbors(adata)
+    sc.tl.umap(adata)
+    sc.tl.leiden(adata, flavor="igraph")
+    return adata
+
+
+def bin_entropy(x, axis=1):
+    """Calculates Shannon entropy with the base of 2 on count data."""
+    x = np.atleast_2d(x).astype(int)
+
+    if axis == 0:
+        x = x.T
+
+    nrows, ncols = x.shape
+    nbins = x.max() + 1
+
+    counts = np.vstack([np.bincount(row, minlength=nbins) for row in x])
+
+    p = counts / float(ncols)
+    p = np.where(p > 0, p, 1)
+
+    return -np.sum(p * np.log2(p), axis=1)
+
+
+def calculate_cluster_entropy(adata, cluster_col):
+    X = adata.X.toarray()
+    cluster_labels = adata.obs[cluster_col].values
+    unique_clusters = np.unique(cluster_labels)
+    n_clusters = len(unique_clusters)
+
+    avg_gene_values = np.zeros((n_clusters, X.shape[1]))
+
+    for i, cluster in enumerate(unique_clusters):
+        cluster_indices = np.where(cluster_labels == cluster)[0]
+
+        avg_gene_values[i, :] = X[cluster_indices].mean(axis=0)
+
+    avg_gene_values_transposed = avg_gene_values.T
+
+    entropies = bin_entropy(avg_gene_values_transposed, axis=1)
+
+    return entropies
+
+
+def get_informative_genes(adata, cluster_col, threshold=0.01):
+    gene_names = adata.var_names
+    entropies = calculate_cluster_entropy(adata, cluster_col)
+    gene_entropies = zip(gene_names, entropies)
+    filtered_genes = filter(lambda x: x[1] > threshold, gene_entropies)
+    return [gene[0] for gene in filtered_genes]
+
+
+def get_tangram_predictions(adata, perc=0, merge=True):
+    tg_ct_pred = adata.obsm["tangram_ct_pred"]
+    tg_ct_pred = tg_ct_pred.clip(tg_ct_pred.quantile(perc), tg_ct_pred.quantile(1 - perc), axis=1)
+    tg_ct_pred = (tg_ct_pred - tg_ct_pred.min()) / (tg_ct_pred.max() - tg_ct_pred.min())
+
+    df = pd.DataFrame()
+    df["tangram_prediction"] = tg_ct_pred.idxmax(axis=1)
+    df["tangram_score"] = tg_ct_pred.apply(lambda x: max(x), axis=1)
+
+    if merge:
+        adata.obs = adata.obs.join(df)
+        return adata
+
+    return df
+
+
+def main():
+    args = _parse_args()
+    adata_xm = sc.read(args.xenium_file.resolve())
+    adata_sc = sc.read(args.reference_file.resolve())
+
+    adata = adata_xm.copy()
+    adata = cluster_adata(adata)
+
+    genes_sc = get_informative_genes(adata_sc, args.cell_type_key)
+    genes_st = get_informative_genes(adata, "leiden")
+
+    genes_shared = np.intersect1d(genes_sc, genes_st)
+    tg.pp_adatas(adata_sc, adata, genes=genes_shared, gene_to_lowercase=False)
+
+    ad_map = tg.map_cells_to_space(
+        adata_sc,
+        adata,
+        mode="clusters",
+        cluster_label=args.cell_type_key,
+        density_prior="uniform",
+        num_epochs=500,
+        device="cuda",
+    )
+
+    tg.plot_training_scores(ad_map, bins=20, alpha=0.5)
+    plt.savefig(args.training_plot, dpi=300, bbox_inches="tight")
+    plt.close()
+
+    tg.project_cell_annotations(ad_map, adata, annotation=args.cell_type_key)
+    adata = get_tangram_predictions(adata)
+
+    tangram_df = adata_xm.obs.join(adata.obs[["tangram_prediction", "tangram_score"]], how="left")
+    adata_xm.obs = tangram_df
+    adata_xm.obs["tangram_prediction"] = adata_xm.obs["tangram_prediction"].fillna("unassigned")
+
+    adata_xm.write_h5ad(args.out.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/config/resources.config
+++ b/config/resources.config
@@ -32,4 +32,12 @@ process {
         memory           = '32 GB'
         time             = '6 h'
     }
+    withName: MAP_REFERENCE {
+        cpus             = 8
+        memory           = '32 GB'
+        time             = '6h'
+        queue            = 'gpu_a100_22c'
+        clusterOptions   = '--gpus a100:1'
+        containerOptions = '--nv'
+    }
 }

--- a/main.nf
+++ b/main.nf
@@ -5,6 +5,7 @@ include { RESEGMENT_NUCLEI }    from './modules/resegment_nuclei.nf'
 include { RESEGMENT_CELLS }     from './modules/resegment_cells.nf'
 include { DETECT_TISSUE }       from './modules/detect_tissue.nf'
 include { SPLIT_SAMPLES }       from './modules/split_samples.nf'
+include { MAP_REFERENCE }       from './modules/map_reference.nf'
 include { IDENTIFY_PROGRAMS }   from './modules/identify_programs.nf'
 
 workflow {
@@ -25,7 +26,9 @@ workflow {
     split_in   = convert_keyed.join( regions_keyed ).map { id, z, r -> tuple( z, r, id ) }
     split_out  = SPLIT_SAMPLES( split_in )
 
-    identify_in   = split_out.flatMap { path, _sample_id -> path }
+    map_out = MAP_REFERENCE( split_out )
+
+    identify_in   = map_out.flatMap { path, _sample_id -> path }
     _identify_out = IDENTIFY_PROGRAMS( identify_in )
 }
 
@@ -56,6 +59,8 @@ workflow TEST {
     split_in   = convert_keyed.join( regions_keyed ).map { id, z, r -> tuple( z, r, id ) }
     split_out  = SPLIT_SAMPLES( split_in )
 
-    identify_in   = split_out.flatMap { path, _sample_id -> path }
+    map_out = MAP_REFERENCE( split_out )
+
+    identify_in   = map_out.flatMap { path, _sample_id -> path }
     _identify_out = IDENTIFY_PROGRAMS( identify_in )
 }

--- a/main.nf
+++ b/main.nf
@@ -36,8 +36,7 @@ workflow {
     }
     _map_out = MAP_REFERENCE( map_in )
 
-    identify_in = map_in.map { h5ad, _id -> h5ad }
-    _identify_out = IDENTIFY_PROGRAMS( identify_in )
+    _identify_out = IDENTIFY_PROGRAMS( map_in )
 }
 
 
@@ -70,8 +69,7 @@ workflow TEST {
     map_in = split_out.flatMap { h5ads, id ->
         h5ads.collect { h5ad -> tuple(h5ad, id) }
     }
-    _map_out = MAP_REFERENCE(map_in)
+    _map_out = MAP_REFERENCE( map_in )
 
-    identify_in = map_in.map { h5ad, _id -> h5ad }
-    _identify_out = IDENTIFY_PROGRAMS( identify_in )
+    _identify_out = IDENTIFY_PROGRAMS( map_in )
 }

--- a/main.nf
+++ b/main.nf
@@ -28,7 +28,7 @@ workflow {
 
     map_out = MAP_REFERENCE( split_out )
 
-    identify_in   = map_out.flatMap { path, _sample_id -> path }
+    identify_in   = map_out.flatMap { path, _training_plot -> path }
     _identify_out = IDENTIFY_PROGRAMS( identify_in )
 }
 
@@ -61,6 +61,6 @@ workflow TEST {
 
     map_out = MAP_REFERENCE( split_out )
 
-    identify_in   = map_out.flatMap { path, _sample_id -> path }
+    identify_in   = map_out.flatMap { path, _training_plot -> path }
     _identify_out = IDENTIFY_PROGRAMS( identify_in )
 }

--- a/main.nf
+++ b/main.nf
@@ -16,7 +16,12 @@ workflow {
 
     convert_out       = CONVERT_XENIUM( xenium_ch )
     nuclei_reseg_out  = RESEGMENT_NUCLEI( convert_out )
-    cells_reseg_out   = RESEGMENT_CELLS( nuclei_reseg_out )
+    if( params.resegment_cells ) {
+            cells_reseg_out = RESEGMENT_CELLS( nuclei_reseg_out )
+    }
+        else {
+            cells_reseg_out = nuclei_reseg_out
+    }
     detect_out        = DETECT_TISSUE( cells_reseg_out )
 
     regions_ch     = detect_out.map { _bbox, regions, _fig, id -> tuple( regions, id ) }
@@ -26,9 +31,12 @@ workflow {
     split_in   = convert_keyed.join( regions_keyed ).map { id, z, r -> tuple( z, r, id ) }
     split_out  = SPLIT_SAMPLES( split_in )
 
-    map_out = MAP_REFERENCE( split_out )
+    map_in = split_out.flatMap { h5ads, id ->
+        h5ads.collect { h5ad -> tuple(h5ad, id) }
+    }
+    _map_out = MAP_REFERENCE( map_in )
 
-    identify_in   = map_out.flatMap { path, _training_plot -> path }
+    identify_in = map_in.map { h5ad, _id -> h5ad }
     _identify_out = IDENTIFY_PROGRAMS( identify_in )
 }
 
@@ -59,8 +67,11 @@ workflow TEST {
     split_in   = convert_keyed.join( regions_keyed ).map { id, z, r -> tuple( z, r, id ) }
     split_out  = SPLIT_SAMPLES( split_in )
 
-    map_out = MAP_REFERENCE( split_out )
+    map_in = split_out.flatMap { h5ads, id ->
+        h5ads.collect { h5ad -> tuple(h5ad, id) }
+    }
+    _map_out = MAP_REFERENCE(map_in)
 
-    identify_in   = map_out.flatMap { path, _training_plot -> path }
+    identify_in = map_in.map { h5ad, _id -> h5ad }
     _identify_out = IDENTIFY_PROGRAMS( identify_in )
 }

--- a/main.nf
+++ b/main.nf
@@ -31,8 +31,8 @@ workflow {
     split_in   = convert_keyed.join( regions_keyed ).map { id, z, r -> tuple( z, r, id ) }
     split_out  = SPLIT_SAMPLES( split_in )
 
-    map_in = split_out.flatMap { h5ads, id ->
-        h5ads.collect { h5ad -> tuple(h5ad, id) }
+    map_in = split_out.flatMap { h5ads, _id ->
+        h5ads.collect { h5ad -> tuple(h5ad, h5ad.baseName) }
     }
     _map_out = MAP_REFERENCE( map_in )
 
@@ -66,8 +66,8 @@ workflow TEST {
     split_in   = convert_keyed.join( regions_keyed ).map { id, z, r -> tuple( z, r, id ) }
     split_out  = SPLIT_SAMPLES( split_in )
 
-    map_in = split_out.flatMap { h5ads, id ->
-        h5ads.collect { h5ad -> tuple(h5ad, id) }
+    map_in = split_out.flatMap { h5ads, _id ->
+        h5ads.collect { h5ad -> tuple(h5ad, h5ad.baseName) }
     }
     _map_out = MAP_REFERENCE( map_in )
 

--- a/modules/identify_programs.nf
+++ b/modules/identify_programs.nf
@@ -13,20 +13,20 @@ process IDENTIFY_PROGRAMS {
     time    params.time
 
     input:
-        path h5ad_file
+        tuple path(h5ad_file), val(sample_id)
 
     output:
-        path "${h5ad_file.baseName}_cnmf"
+        path "${sample_id}_cnmf"
 
     script:
     """
-    export uid=${h5ad_file.baseName}
     source /opt/conda/etc/profile.d/conda.sh
     conda activate spatial
 
     identify_cnmf_programs.py \
         --h5ad              ${h5ad_file} \
-        --out-dir           \${uid}_cnmf \
+        --id                ${sample_id} \
+        --out-dir           ${sample_id}_cnmf \
         --components        ${params.cnmf_components} \
         --n-iter            ${params.cnmf_n_iter} \
         --num-highvar-genes ${params.cnmf_n_highvar} \

--- a/modules/map_reference.nf
+++ b/modules/map_reference.nf
@@ -1,0 +1,37 @@
+/*
+ * Module: MAP_REFERENCE
+ * Maps cell types from reference single-cell dataset to the spatial.
+ */
+
+process MAP_REFERENCE {
+    tag        "${sample_id}"
+    publishDir "${workflow.launchDir}/${params.outdir_root}/${params.outdir_mapped}", mode: 'copy'
+    container  "${params.containerdir}/sopa_gpu.sif" 
+
+    cpus           params.cpus
+    memory         params.mem
+    time           params.time
+    queue          params.queue
+    clusterOptions params.cluster_opts
+
+    input:
+        tuple path(h5ad_file), val(sample_id)
+
+    output:
+        path "${h5ad_file.baseName}_mapped"
+
+    script:
+    """
+    export uid=${h5ad_file.baseName}
+    source /opt/conda/etc/profile.d/conda.sh
+    conda activate spatial
+
+    map_reference.py \
+        --xenium-file ${h5ad_file} \
+        --reference-file ${params.reference_dataset} \
+        --out \${uid}_mapped.h5ad \
+        --cell-type-key ${params.cell_type_key} \
+        --training-plot "training_scores.png"
+    """
+
+}

--- a/modules/map_reference.nf
+++ b/modules/map_reference.nf
@@ -18,7 +18,9 @@ process MAP_REFERENCE {
         tuple path(h5ad_file), val(sample_id)
 
     output:
-        path "${h5ad_file.baseName}_mapped"
+        tuple \
+            path("${h5ad_file.baseName}_mapped.h5ad"), \
+            path("training_scores.png")
 
     script:
     """

--- a/modules/map_reference.nf
+++ b/modules/map_reference.nf
@@ -20,7 +20,8 @@ process MAP_REFERENCE {
     output:
         tuple \
             path("${h5ad_file.baseName}_mapped.h5ad"), \
-            path("training_scores.png")
+            path("${sample_id}_training_scores.png"), \
+            val(sample_id)
 
     script:
     """
@@ -33,7 +34,7 @@ process MAP_REFERENCE {
         --reference-file ${params.reference_dataset} \
         --out \${uid}_mapped.h5ad \
         --cell-type-key ${params.cell_type_key} \
-        --training-plot "training_scores.png"
+        --training-plot ${sample_id}_training_scores.png
     """
 
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -10,7 +10,7 @@ params {
     outdir_reseg        = '02_resegment_cells'
     outdir_coords       = '03_tissue_coords'
     outdir_h5ad         = '04_h5ad'
-    output_mapped       = '05_mapped'
+    outdir_mapped       = '05_mapped'
     outdir_programs     = '06_cnmf'
     containerdir        = System.getenv('CONTAINERDIR')
     

--- a/nextflow.config
+++ b/nextflow.config
@@ -21,7 +21,7 @@ params {
     cluster_opts    = ''
 
     // Toggle pipeline steps on/off
-    resegment_cells = false
+    resegment_cells = true
     
     // ---------- Step parameters ----------
     // ---------- Nuclei re-segmentation ----------
@@ -80,6 +80,10 @@ params {
 
     // Tissue detection
     detect_tissue_kernel_size = 100 // Kernel size (pixels) used to smooth the tissue mask
+
+    // Reference mapping
+    reference_dataset = null // Path to reference
+    cell_type_key = "cell_type"
 
     // Program identification (cNMF)
     cnmf_components = '7,30'   // Min/max number of components (K) in cNMF as comma-separated integers (no spaces)

--- a/nextflow.config
+++ b/nextflow.config
@@ -10,7 +10,8 @@ params {
     outdir_reseg        = '02_resegment_cells'
     outdir_coords       = '03_tissue_coords'
     outdir_h5ad         = '04_h5ad'
-    outdir_programs     = '05_cnmf'
+    output_mapped       = '05_mapped'
+    outdir_programs     = '06_cnmf'
     containerdir        = System.getenv('CONTAINERDIR')
     
     // Global resource defaults


### PR DESCRIPTION
## Summary

This PR adds a new `MAP_REFERENCE` step to the pipeline to map cell-type labels from a reference single-cell dataset

## Changes

- add new `MAP_REFERENCE` Nextflow module
- add `bin/map_reference.py` using Scanpy + Tangram for reference mapping
- save mapped H5AD outputs plus Tangram training score plots